### PR TITLE
Update C-git-commands.asc with a new TextEdit command

### DIFF
--- a/C-git-commands.asc
+++ b/C-git-commands.asc
@@ -62,7 +62,7 @@ Accompanying the configuration instructions in <<ch01-getting-started#_editor>>,
 |Scratch (Linux)|`git config --global core.editor "scratch-text-editor"`
 |Sublime Text (macOS) |`git config --global core.editor "/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl --new-window --wait"`
 |Sublime Text (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\Sublime Text 3\sublime_text.exe' -w"` (Also see note below)
-|TextEdit (macOS)|`git config --global core.editor "open --wait-apps --new -e"`
+|TextEdit (macOS)|`git config --global core.editor "open -W -n"`
 |Textmate |`git config --global core.editor "mate -w"`
 |Textpad (Windows 64-bit) |`git config --global core.editor "'C:\Program Files\TextPad 5\TextPad.exe' -m` (Also see note below)
 |UltraEdit (Windows 64-bit) | `git config --global core.editor Uedit32`


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Before you start on a large rewrite or other major change: open a new issue first, to discuss the proposed changes. -->
<!-- Should your changes appear in a printed edition, you'll be included in the contributors list. -->

<!-- Mark the checkbox [X] or [x] if you agree with the item. -->
- [ x] I provide my work under the [project license](https://github.com/progit/progit2/blob/master/LICENSE.asc).
- [ x] I grant such license of my work as is required for the purposes of future print editions to [Ben Straub](https://github.com/ben) and [Scott Chacon](https://github.com/schacon).

## Changes

- Update C-git-commands.asc with a new TextEdit command

## Context
<!--
List related issues.
Provide the necessary context to understand the changes you made.

Are you fixing an issue with this pull-request?
Use the "Fixes" keyword, to close the issue automatically after your work is merged.

Fixes #123
Fixes #456
-->
The existing `git config` instructions for TextEdit on Mac would hang after closing the TextEdit program.  The instructions outlined in https://ericasadun.com/2018/07/12/using-textedit-as-your-git-editor/ worked and I propose updating the book with her solution.